### PR TITLE
Case insensitive Check for file extension

### DIFF
--- a/Iptc.php
+++ b/Iptc.php
@@ -133,7 +133,7 @@ class Iptc
             );
         }
         
-        if ( ! in_array(end(explode('.', $filename)), $this->_allowedExt) ) {
+        if ( ! in_array(end(explode('.', strtolower($filename))), $this->_allowedExt) ) {
             include 'Iptc/Exception.php';
             throw new Iptc_Exception(
                 'Support only for the following extensions: ' . 


### PR DESCRIPTION
This line 

```
    if ( ! in_array(end(explode('.', $filename)), $this->_allowedExt) ) {
```

fails if files are named .JPG which can happen a lot on windows with files straight from a camera etc.  Changed to this

```
    if ( ! in_array(end(explode('.', strtolower($filename))), $this->_allowedExt) ) {
```

to avoid raising error.
