### PR TITLE
fix for "Only variables should be passed by reference" error

### DIFF
--- a/Iptc.php
+++ b/Iptc.php
@@ -132,8 +132,10 @@ class Iptc
                 "File \"{$filename}\" is not writable!"
             );
         }
+
+        $parts = explode('.', strtolower($filename));
         
-        if ( ! in_array(end(explode('.', strtolower($filename))), $this->_allowedExt) ) {
+        if ( ! in_array(end($parts), $this->_allowedExt) ) {
             include 'Iptc/Exception.php';
             throw new Iptc_Exception(
                 'Support only for the following extensions: ' . 


### PR DESCRIPTION
A fix for "Only variables should be passed by reference" error on PHP 5.3.26.
